### PR TITLE
新規登録 api の実装【新規登録・ログイン・ログアウト機能の実装】

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.permit(:name, :email)
+  end
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,11 +1,11 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   private
 
-  def sign_up_params
-    params.permit(:name, :email, :password, :password_confirmation)
-  end
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
 
-  def account_update_params
-    params.permit(:name, :email)
-  end
+    def account_update_params
+      params.permit(:name, :email)
+    end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false #リクエストごとにtokenを新しくしない設定。
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks #tokenの有効期間で、２週間に設定
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -41,12 +41,12 @@ DeviseTokenAuth.setup do |config|
   # It depends on fields like email, provider and uid.
   # config.default_callbacks = true
 
-  # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  # Makes it possible to change the headers names(認証用ヘッダーの名前の定義)
+  config.headers_names = {:'access-token' => 'access-token',
+                         :'client' => 'client',
+                         :'expiry' => 'expiry',
+                         :'uid' => 'uid',
+                         :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  config.change_headers_on_each_request = false #リクエストごとにtokenを新しくしない設定。
+  config.change_headers_on_each_request = false # リクエストごとにtokenを新しくしない設定。
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  config.token_lifespan = 2.weeks #tokenの有効期間で、２週間に設定
+  config.token_lifespan = 2.weeks # tokenの有効期間で、２週間に設定
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names(認証用ヘッダーの名前の定義)
-  config.headers_names = {:'access-token' => 'access-token',
-                         :'client' => 'client',
-                         :'expiry' => 'expiry',
-                         :'uid' => 'uid',
-                         :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations"
+      }
       resources :articles
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: "api/v1/auth/registrations"
+        registrations: "api/v1/auth/registrations",
       }
       resources :articles
     end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
name カラムを既存メソッドに付与したいためdevise_token_auth のメソッドをオーバーライド
新規登録時にレスポンスとして返される header 情報の設定