### PR TITLE
既存apiの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 module Api::V1
   # base_api_controller を継承
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  # current_user のダミーコード
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -49,16 +49,15 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) } # createを確認するためのテストと明確
+    subject { post(api_v1_articles_path, params: params, headers: headers) } # createを確認するためのテストと明確
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-
-    # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) } # rubocop:disable Spec/AnyInstance
+    let(:headers) { current_user.create_new_auth_token }
 
     context "適切なパラメータを送信したとき" do
       it "記事が１つ作成される" do
+
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1) # APIを叩いた前後で、Aricle.countが1増えることをチェック
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
@@ -69,13 +68,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH(PUT) /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-
-    # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) } # rubocop:disable Spec/AnyInstance
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事のレコードを更新しようとするとき" do
       let(:article) { create(:article, user: current_user) }
@@ -97,12 +94,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
-
-    # stub
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) } # rubocop:disable Spec/AnyInstance
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を削除しようとするとき" do
       let!(:article) { create(:article, user: current_user) }
@@ -122,5 +117,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
                               change { Article.count }.by(0)
       end
     end
+    
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "適切なパラメータを送信したとき" do
       it "記事が１つ作成される" do
-
         expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1) # APIを叩いた前後で、Aricle.countが1増えることをチェック
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
@@ -117,6 +116,5 @@ RSpec.describe "Api::V1::Articles", type: :request do
                               change { Article.count }.by(0)
       end
     end
-    
   end
 end


### PR DESCRIPTION
current_userのダミーメソッドを削除
devise_token_auth のヘルパーメソッド をエイリアスで使えるように
authenticate_user! を実装[:create, :update, :destroy]
テストでログインが必要な API を叩く際に headers を渡すように実装