### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,8 +3,9 @@
 # Table name: articles
 #
 #  id         :bigint           not null, primary key
-#  body       :text
-#  title      :string
+#  body       :text             not null
+#  status     :string           default("draft"), not null
+#  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null
@@ -23,4 +24,6 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :title, :body, presence: true
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20220307152223_create_articles.rb
+++ b/db/migrate/20220307152223_create_articles.rb
@@ -1,10 +1,10 @@
 class CreateArticles < ActiveRecord::Migration[6.0]
   def change
     create_table :articles do |t|
-      t.string :title
-      t.text :body
-      t.references :user, null: false, foreign_key: true
-
+      t.string     :title,  null: false
+      t.text       :body,   null: false
+      t.references :user,   null: false, foreign_key: true
+      t.string     :status, null: false, default: "draft"
       t.timestamps
     end
   end

--- a/db/migrate/20220307153119_create_article_likes.rb
+++ b/db/migrate/20220307153119_create_article_likes.rb
@@ -1,7 +1,7 @@
 class CreateArticleLikes < ActiveRecord::Migration[6.0]
   def change
     create_table :article_likes do |t|
-      t.references :user, null: false, foreign_key: true
+      t.references :user,    null: false, foreign_key: true
       t.references :article, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20220307153220_create_comments.rb
+++ b/db/migrate/20220307153220_create_comments.rb
@@ -2,7 +2,7 @@ class CreateComments < ActiveRecord::Migration[6.0]
   def change
     create_table :comments do |t|
       t.text :body
-      t.references :user, null: false, foreign_key: true
+      t.references :user,    null: false, foreign_key: true
       t.references :article, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,9 +25,10 @@ ActiveRecord::Schema.define(version: 2022_03_07_153220) do
   end
 
   create_table "articles", force: :cascade do |t|
-    t.string "title"
-    t.text "body"
+    t.string "title", null: false
+    t.text "body", null: false
     t.bigint "user_id", null: false
+    t.string "status", default: "draft", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -23,5 +23,13 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     association :user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,8 +3,9 @@
 # Table name: articles
 #
 #  id         :bigint           not null, primary key
-#  body       :text
-#  title      :string
+#  body       :text             not null
+#  status     :string           default("draft"), not null
+#  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,27 +21,42 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "必要な情報が揃っている場合" do
-    let(:article) { build(:article) }
+  describe "正常系" do
+    context "必要な情報が揃っている場合" do
+      let(:article_draft) { build(:article, :draft) }
+      let(:article_published) { build(:article, :published) }
 
-    it "記事が投稿できる" do
-      expect(article).to be_valid
+      it "下書きが保存できる" do
+        expect(article_draft).to be_valid
+        expect(article_draft.status).to eq "draft"
+      end
+
+      it "記事が投稿できる(公開記事として保存される)" do
+        expect(article_published).to be_valid
+        expect(article_published.status).to eq "published"
+      end
+
     end
   end
 
-  context "bodyのみ入力している場合" do
-    let(:article) { build(:article, title: nil) }
+  describe "異常系" do
+    context "bodyのみ入力している場合" do
+      let(:article) { build(:article, title: nil) }
 
-    it "エラーが発生する" do
-      expect(article).not_to be_valid
+      it "エラーが発生する" do
+        expect(article).not_to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "title がない場合" do
+      let(:article) { build(:article, body: nil) }
+
+      it "エラーが発生する" do
+        expect(article).not_to be_valid
+        expect(article.status).to eq "draft"
+      end
     end
   end
 
-  context "title がない場合" do
-    let(:article) { build(:article, body: nil) }
-
-    it "エラーが発生する" do
-      expect(article).not_to be_valid
-    end
-  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,8 +3,9 @@
 # Table name: articles
 #
 #  id         :bigint           not null, primary key
-#  body       :text
-#  title      :string
+#  body       :text             not null
+#  status     :string           default("draft"), not null
+#  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Article, type: :model do
         expect(article_published).to be_valid
         expect(article_published.status).to eq "published"
       end
-
     end
   end
 
@@ -58,5 +57,4 @@ RSpec.describe Article, type: :model do
       end
     end
   end
-
 end


### PR DESCRIPTION
記事の下書きの状態と公開の状態の２つを作成
記事の状態に関するカラムを追加
記事の models spec に上記実装を反映